### PR TITLE
[PR-005] フレーズ登録・編集・削除機能の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,35 @@
 
 ### 起動方法
 
-1.  PostgreSQL データベースがローカルまたは別の Docker コンテナで稼働していることを確認してください。(`docker-compose.yml` でデータベースサービスを定義している場合は不要です)。
-2.  `.env` ファイルに必要な環境変数 (特に `DATABASE_URL`) が設定されていることを確認してください。
-3.  以下のコマンドを実行します。
+1.  プロジェクトルートに `.env` ファイルを作成し、以下の環境変数を設定します。サンプルとして `.env.example` があればそれをコピーして編集してください。
+    *   `DATABASE_URL`: PostgreSQL データベースの接続URL (例: `postgresql://user:password@db:5432/mydatabase`)
+    *   `GOOGLE_CLIENT_ID`: Google Cloud Console で取得したクライアント ID
+    *   `GOOGLE_CLIENT_SECRET`: Google Cloud Console で取得したクライアントシークレット
+    *   `NEXTAUTH_SECRET`: `openssl rand -hex 32` などで生成したランダムな文字列
+2.  以下のコマンドを実行します。
 
     ```bash
-    docker-compose up --build
+    docker compose up --build
     ```
 
 これにより、依存関係のインストール、Prisma Client の生成、データベースマイグレーションの適用、Next.js 開発サーバーの起動が自動で行われます。アプリケーションは `http://localhost:3000` でアクセス可能になります。
 
+### データベースの確認 (Prisma Studio)
+
+開発中にデータベースの内容を確認するには、Prisma Studio が便利です。
+
+1.  `docker compose up` を実行しているターミナルとは**別のターミナル**を開きます。
+2.  以下のコマンドを実行して、`web` コンテナ内で Prisma Studio を起動します。
+
+    ```bash
+    docker compose exec web npx prisma studio
+    ```
+
+3.  ブラウザで `http://localhost:5555` にアクセスします。
+
 ### 動作の仕組み
 
-`docker-compose up` を実行すると、以下の処理が順に行われます。
+`docker compose up` を実行すると、以下の処理が順に行われます。
 
 1.  `Dockerfile` に基づいて Docker イメージがビルドされます。
     *   Node.js 環境のセットアップ
@@ -28,3 +44,12 @@
 3.  `entrypoint.sh` スクリプトが実行されます。
     *   データベースマイグレーションが適用されます (`npx prisma migrate dev`)。
 4.  Next.js 開発サーバーが起動します (`npm run dev`)。
+
+## 主な機能 (開発中)
+
+### フレーズ登録
+
+-   URL: `/phrases/new`
+-   ログイン後、ABC Notation 形式でフレーズ、コメント、タグ（カンマ区切り）を入力して登録できます。
+-   入力された ABC Notation はリアルタイムでプレビュー表示され、構文エラーやレンダリングエラーがある場合はエラーメッセージが表示され、登録ボタンが無効になります。
+-   登録されたフレーズとタグはデータベースに保存されます。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     build: .
     ports:
       - "3000:3000"
+      - "5555:5555"
     volumes:
       - .:/app
       - /app/node_modules

--- a/src/app/api/phrases/[id]/route.ts
+++ b/src/app/api/phrases/[id]/route.ts
@@ -1,0 +1,208 @@
+import { NextResponse } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+import { auth } from "@/auth";
+import { parseAbcNotation } from '@/lib/abcParser';
+
+const prisma = new PrismaClient();
+
+export async function GET(
+    request: Request,
+    { params }: { params: { id: string } }
+) {
+    await request.text(); // Read body/end stream to allow accessing params safely
+    const session = await auth();
+    const phraseId = params.id;
+
+    if (!phraseId) {
+        return NextResponse.json({ error: 'Phrase ID is required' }, { status: 400 });
+    }
+
+    try {
+        const phrase = await prisma.phrase.findUnique({
+            where: { id: phraseId },
+            include: {
+                tags: { // Include associated tags
+                    select: { name: true } // Only select tag names
+                },
+                user: { // Optionally include user info (be careful with sensitive data)
+                    select: { id: true, name: true, image: true }
+                }
+            }
+        });
+
+        if (!phrase) {
+            return NextResponse.json({ error: 'Phrase not found' }, { status: 404 });
+        }
+
+        // Authorization Check:
+        // If the phrase is not public, only the owner can access it.
+        // For now, assume all phrases require ownership check until public feature is implemented.
+        if (!session || !session.user?.id || phrase.userId !== session.user.id) {
+             // Check if user is logged in and owns the phrase
+             // Consider making public phrases accessible later
+             return NextResponse.json({ error: 'Forbidden or Not Found' }, { status: 403 }); // Or 404
+        }
+
+        // Exclude sensitive data if necessary before sending
+        // const { userId, ...phraseData } = phrase; // Example
+
+        return NextResponse.json(phrase);
+
+    } catch (error) {
+        console.error(`Error fetching phrase ${phraseId}:`, error);
+        return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+    }
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  await request.text(); // Read body/end stream to allow accessing params safely
+  const session = await auth();
+
+  if (!session || !session.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const userId = session.user.id;
+  const phraseId = params.id;
+
+  if (!phraseId) {
+    return NextResponse.json({ error: 'Phrase ID is required' }, { status: 400 });
+  }
+
+  try {
+    // Find the phrase first to check ownership
+    const phrase = await prisma.phrase.findUnique({
+      where: { id: phraseId },
+      select: { userId: true }, // Select only the userId for checking
+    });
+
+    // If phrase doesn't exist
+    if (!phrase) {
+      return NextResponse.json({ error: 'Phrase not found' }, { status: 404 });
+    }
+
+    // Authorization check: Ensure the user owns the phrase
+    if (phrase.userId !== userId) {
+      // Return 404 to avoid leaking information about phrase existence
+      return NextResponse.json({ error: 'Phrase not found' }, { status: 404 });
+      // Alternatively, return 403 Forbidden if you want to be more explicit
+      // return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    // Delete the phrase
+    await prisma.phrase.delete({
+      where: { id: phraseId },
+    });
+
+    console.log(`User ${userId} deleted phrase ${phraseId}`);
+
+    // Return 204 No Content on successful deletion
+    return new NextResponse(null, { status: 204 });
+
+  } catch (error) {
+    console.error(`Error deleting phrase ${phraseId} for user ${userId}:`, error);
+    if (error instanceof Error && error.name === 'PrismaClientKnownRequestError' && (error as any).code === 'P2025') {
+        // Handle case where record to delete is not found (already deleted, race condition)
+        return NextResponse.json({ error: 'Phrase not found' }, { status: 404 });
+    }
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}
+
+export async function PUT(
+    request: Request,
+    { params }: { params: { id: string } }
+) {
+    // For PUT, we need the body, so request.json() implicitly handles this.
+    // No need to add await request.text() here if request.json() is called before accessing params.
+    const session = await auth();
+
+    if (!session || !session.user?.id) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const userId = session.user.id;
+    const phraseId = params.id;
+
+    if (!phraseId) {
+        return NextResponse.json({ error: 'Phrase ID is required' }, { status: 400 });
+    }
+
+    try {
+        // Reading the body here makes accessing params safe afterwards
+        const body = await request.json();
+        const { abcNotation, comment, tags: tagNames } = body;
+
+        // --- Input Validation ---
+        if (!abcNotation || typeof abcNotation !== 'string' || !abcNotation.trim()) {
+            return NextResponse.json({ error: 'abcNotation is required and must be a non-empty string' }, { status: 400 });
+        }
+        if (comment !== undefined && comment !== null && typeof comment !== 'string') {
+            return NextResponse.json({ error: 'comment must be a string or null' }, { status: 400 });
+        }
+        if (!Array.isArray(tagNames) || !tagNames.every(tag => typeof tag === 'string')) {
+            return NextResponse.json({ error: 'tags must be an array of strings' }, { status: 400 });
+        }
+
+        // --- Find Phrase and Check Ownership ---
+        const existingPhrase = await prisma.phrase.findUnique({
+            where: { id: phraseId },
+            select: { userId: true },
+        });
+
+        if (!existingPhrase) {
+            return NextResponse.json({ error: 'Phrase not found' }, { status: 404 });
+        }
+
+        if (existingPhrase.userId !== userId) {
+            return NextResponse.json({ error: 'Forbidden or Not Found' }, { status: 403 }); // Or 404
+        }
+
+        // --- Extract Original Key ---
+        let originalKey = 'C'; // Default key
+        const parsed = parseAbcNotation(abcNotation);
+        if (parsed && parsed.header?.key) {
+            originalKey = parsed.header.key;
+        }
+
+        // --- Process Tags --- (Similar to POST, using set for replacement)
+        const tagConnectOrCreate = tagNames.map(name => ({
+            where: { name },
+            create: { name, type: 'user_defined', userId },
+        }));
+
+        // --- Update Phrase in DB ---
+        const updatedPhrase = await prisma.phrase.update({
+            where: { id: phraseId },
+            data: {
+                abcNotation,
+                originalKey,
+                comment: comment,
+                tags: {
+                    // Disconnect all existing tags first, then connect/create new ones
+                    set: [], // Disconnect all first
+                    connectOrCreate: tagConnectOrCreate, // Then connect/create
+                }
+            },
+            include: { // Include updated tags in the response
+                tags: true,
+            }
+        });
+
+        console.log(`User ${userId} updated phrase ${phraseId}`);
+
+        return NextResponse.json(updatedPhrase);
+
+    } catch (error) {
+        console.error(`Error updating phrase ${phraseId} for user ${userId}:`, error);
+        if (error instanceof SyntaxError) {
+            return NextResponse.json({ error: 'Invalid JSON format' }, { status: 400 });
+        } else if (error instanceof Error && error.name === 'PrismaClientValidationError') {
+            return NextResponse.json({ error: 'Database validation error.', details: error.message }, { status: 400 });
+        }
+        return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+    }
+}
+
+// You might add GET and PUT/PATCH handlers here later for fetching/editing

--- a/src/app/api/phrases/route.ts
+++ b/src/app/api/phrases/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+import { auth } from "@/auth";
+import { parseAbcNotation } from '@/lib/abcParser';
+
+const prisma = new PrismaClient();
+
+export async function POST(request: Request) {
+  const session = await auth();
+
+  if (!session || !session.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const userId = session.user.id;
+
+  try {
+    const body = await request.json();
+    const { abcNotation, comment, tags: tagNames } = body;
+
+    if (!abcNotation || typeof abcNotation !== 'string' || !abcNotation.trim()) {
+      return NextResponse.json({ error: 'abcNotation is required and must be a non-empty string' }, { status: 400 });
+    }
+    if (comment && typeof comment !== 'string') {
+        return NextResponse.json({ error: 'comment must be a string' }, { status: 400 });
+    }
+    if (!Array.isArray(tagNames) || !tagNames.every(tag => typeof tag === 'string')) {
+        return NextResponse.json({ error: 'tags must be an array of strings' }, { status: 400 });
+    }
+
+    let originalKey = 'C';
+    const parsed = parseAbcNotation(abcNotation);
+    if (parsed && parsed.header?.key) {
+        originalKey = parsed.header.key;
+    }
+
+    console.log(`User ${userId} creating phrase. Key: ${originalKey}, Comment: ${comment}, Tags: ${tagNames.join(', ')}`);
+
+    // --- Process Tags --- Find existing or create new tags
+    const tagConnectOrCreate = tagNames.map(name => ({
+        where: { name }, // Find tag by unique name
+        create: { name, type: 'user_defined', userId }, // Create if not found
+    }));
+
+    // --- Create Phrase in DB --- (Now including tag connection)
+    const newPhrase = await prisma.phrase.create({
+        data: {
+            abcNotation,
+            originalKey,
+            comment: comment || null,
+            userId,
+            tags: {
+                connectOrCreate: tagConnectOrCreate, // Use connectOrCreate for tags
+            }
+        },
+        include: { // Optionally include tags in the response
+            tags: true,
+        }
+    });
+
+    // Return the full created phrase object including tags
+    return NextResponse.json(newPhrase, { status: 201 });
+
+  } catch (error) {
+    console.error(`Error creating phrase for user ${userId}:`, error);
+    if (error instanceof SyntaxError) {
+      return NextResponse.json({ error: 'Invalid JSON format' }, { status: 400 });
+    } else if (error instanceof Error && error.name === 'PrismaClientValidationError') {
+        return NextResponse.json({ error: 'Database validation error.', details: error.message }, { status: 400 });
+    }
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}
+
+// You might want to add a GET handler later to fetch phrases
+// export async function GET(request: Request) {
+//   // ... implementation ...
+// }

--- a/src/app/phrases/[id]/edit/page.tsx
+++ b/src/app/phrases/[id]/edit/page.tsx
@@ -1,0 +1,274 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { useParams, useRouter } from 'next/navigation'; // Import hooks for route params and navigation
+import { parseAbcNotation, AbcHeader } from '@/lib/abcParser';
+import dynamic from 'next/dynamic';
+
+// Dynamically import the renderer component, disabling SSR
+const AbcNotationRenderer = dynamic(() => import('@/components/AbcNotationRenderer'), {
+  ssr: false,
+  loading: () => <p>Loading renderer...</p> // Optional loading indicator
+});
+
+// Define type for the fetched phrase data (adjust based on actual API response)
+interface PhraseData {
+    id: string;
+    abcNotation: string;
+    comment: string | null;
+    tags: { name: string }[]; // Assuming API returns tags like this
+    // Add other relevant fields if needed
+}
+
+const EditPhrasePage: React.FC = () => {
+  const router = useRouter();
+  const params = useParams();
+  const phraseId = params?.id as string; // Get phrase ID from route
+
+  // State for form fields
+  const [abcInput, setAbcInput] = useState<string>(''); // Initialize empty
+  const [comment, setComment] = useState<string>('');
+  const [tagsInput, setTagsInput] = useState<string>('');
+
+  // State for validation and submission
+  const [parsedHeader, setParsedHeader] = useState<AbcHeader | null>(null);
+  const [parseError, setParseError] = useState<string>('');
+  const [renderError, setRenderError] = useState<Error | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const [submitError, setSubmitError] = useState<string>('');
+
+  // State for loading phrase data
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [loadError, setLoadError] = useState<string>('');
+
+  // --- Fetch existing phrase data --- (Runs once on mount)
+  useEffect(() => {
+    if (!phraseId) {
+      setLoadError('Invalid Phrase ID.');
+      setIsLoading(false);
+      return;
+    }
+
+    const fetchPhrase = async () => {
+      setIsLoading(true);
+      setLoadError('');
+      try {
+        const response = await fetch(`/api/phrases/${phraseId}`);
+        if (!response.ok) {
+          const errorData = await response.json();
+          if (response.status === 403 || response.status === 404) {
+            throw new Error('フレーズが見つからないか、アクセス権がありません。');
+          } else {
+            throw new Error(errorData.error || `HTTP error! status: ${response.status}`);
+          }
+        }
+        const data: PhraseData = await response.json();
+
+        // Set form state with fetched data
+        setAbcInput(data.abcNotation || '');
+        setComment(data.comment || '');
+        setTagsInput(data.tags?.map(tag => tag.name).join(', ') || ''); // Join tag names for input
+
+      } catch (error) {
+        console.error('Error fetching phrase:', error);
+        setLoadError(`データの読み込みに失敗しました: ${error instanceof Error ? error.message : String(error)}`);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchPhrase();
+  }, [phraseId]);
+
+  // Parses header, does not validate syntax deeply
+  const handleValidation = useCallback(() => {
+    setParseError(''); // Reset parse error initially
+    setParsedHeader(null);
+    setRenderError(null); // Also reset render error, it will be set by the renderer
+
+    if (!abcInput.trim()) {
+        // If input is empty or only whitespace, clear header and return
+        setParsedHeader(null);
+        return;
+    }
+
+    try {
+      const result = parseAbcNotation(abcInput);
+      if (result) {
+        setParsedHeader(result.header);
+      } else {
+        // This case might be less likely now, but keep for unexpected issues
+        setParseError('Failed to process ABC notation.');
+      }
+    } catch (error) {
+      // Catch internal errors during basic parsing
+      console.error('Internal parsing error:', error);
+      setParseError(`An internal error occurred during parsing: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }, [abcInput]);
+
+  useEffect(() => {
+    handleValidation();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [handleValidation]);
+
+  // Memoize handleRenderError to prevent infinite loops
+  const handleRenderError = useCallback((error: Error | null) => {
+    // Optimize state updates: only update if the value actually changes
+    setRenderError(currentError => {
+      // Basic comparison for Error objects (might need refinement if error identity changes)
+      if (currentError?.message === error?.message) return currentError;
+      return error;
+    });
+    if (error) {
+      setParseError(''); // Clear internal parse error if render error occurs
+    }
+  }, []);
+
+  // Validity now primarily depends on the renderError and submission status
+  const isValidForSubmission = !renderError && !isSubmitting && !isLoading && !loadError;
+
+  const handleUpdate = async () => {
+    if (!isValidForSubmission || !phraseId) {
+      console.error("Validation failed, already submitting, or missing ID. Cannot update.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setSubmitError('');
+
+    const tags = tagsInput.split(',').map(tag => tag.trim()).filter(tag => tag !== '');
+
+    try {
+      const response = await fetch(`/api/phrases/${phraseId}`, { // Use PUT and include ID
+        method: 'PUT', // Use PUT method
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ abcNotation: abcInput, comment, tags }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || `HTTP error! status: ${response.status}`);
+      }
+
+      const updatedPhrase = await response.json();
+      console.log('Phrase updated successfully:', updatedPhrase);
+      alert(`フレーズが更新されました！`);
+      // Optionally redirect after update
+      // router.push(`/phrases/${phraseId}`); // Redirect to detail page (if exists)
+      router.back(); // Or simply go back
+
+    } catch (error) {
+      console.error('Error updating phrase:', error);
+      setSubmitError(`更新中にエラーが発生しました: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // --- Render Logic ---
+  if (isLoading) {
+    return <div className="container mx-auto p-4">読み込み中...</div>;
+  }
+
+  if (loadError) {
+    return <div className="container mx-auto p-4 text-red-500">エラー: {loadError}</div>;
+  }
+
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">フレーズの編集</h1>
+
+      {/* Use handleUpdate for form submission */}
+      <form onSubmit={(e) => { e.preventDefault(); handleUpdate(); }}>
+        {/* Form fields are mostly the same, just populated with initial data */}
+        <div className="mb-6">
+          <label htmlFor="abcInput" className="block text-xl font-semibold mb-2">ABC Notation:</label>
+          <textarea
+            id="abcInput"
+            className="w-full h-60 p-2 border rounded font-mono text-sm"
+            value={abcInput}
+            onChange={(e) => setAbcInput(e.target.value)}
+            placeholder="X:1\nT:Title\nM:4/4\nL:1/8\nK:C\nCDEF|GABc|"
+            required
+            disabled={isLoading} // Disable while loading initial data
+          />
+        </div>
+
+        <div className="mb-6">
+          <label htmlFor="comment" className="block text-xl font-semibold mb-2">コメント:</label>
+          <textarea
+            id="comment"
+            className="w-full h-20 p-2 border rounded text-sm"
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+            placeholder="フレーズの説明や使い方のメモなど"
+            disabled={isLoading}
+          />
+        </div>
+
+        <div className="mb-6">
+          <label htmlFor="tagsInput" className="block text-xl font-semibold mb-2">タグ (カンマ区切り):</label>
+          <input
+            type="text"
+            id="tagsInput"
+            className="w-full p-2 border rounded text-sm"
+            value={tagsInput}
+            onChange={(e) => setTagsInput(e.target.value)}
+            placeholder="例: Major 2-5-1, Bebop Scale, Lick"
+            disabled={isLoading}
+          />
+        </div>
+
+        {(parseError || renderError || submitError) && (
+          <div className="mb-4 p-3 bg-red-100 text-red-700 border border-red-400 rounded">
+            {/* Display internal parse error only if no render error exists */}
+            {parseError && !renderError && <p><strong>内部パースエラー:</strong> {parseError}</p>}
+            {renderError && <p><strong>楽譜レンダリングエラー:</strong> {renderError.message}</p>}
+            {submitError && <p><strong>更新エラー:</strong> {submitError}</p>}
+          </div>
+        )}
+
+        {/* Display parsed header only if no render error and header exists */}
+        {!renderError && parsedHeader && (
+          <div className="mb-6 p-4 border rounded bg-gray-50">
+            <h2 className="text-xl font-semibold mb-2">Parsed Header Information:</h2>
+            <pre className="text-sm">{JSON.stringify(parsedHeader, null, 2)}</pre>
+          </div>
+        )}
+
+        <div>
+          <h2 className="text-xl font-semibold mb-2">Preview:</h2>
+          <div className="p-4 border rounded min-h-[100px]">
+            {/* Pass the handleRenderError callback */}
+            <AbcNotationRenderer abcNotation={abcInput} onError={handleRenderError} />
+          </div>
+        </div>
+
+        {/* Update Button */}
+        <div className="mt-6">
+          <button
+            type="submit"
+            className={`px-4 py-2 rounded ${isValidForSubmission ? 'bg-blue-500 text-white hover:bg-blue-600' : 'bg-gray-300 text-gray-500 cursor-not-allowed'}`}
+            disabled={!isValidForSubmission}
+          >
+            {isSubmitting ? '更新中...' : '更新'}
+          </button>
+           <button
+                type="button"
+                onClick={() => router.back()} // Go back without saving
+                className="ml-4 px-4 py-2 rounded bg-gray-200 text-gray-700 hover:bg-gray-300"
+                disabled={isSubmitting}
+            >
+                キャンセル
+            </button>
+        </div>
+      </form>
+
+    </div>
+  );
+};
+
+export default EditPhrasePage;
+
+

--- a/src/app/phrases/new/page.tsx
+++ b/src/app/phrases/new/page.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+// import AbcNotationRenderer from '@/components/AbcNotationRenderer'; // Direct import removed
+import { parseAbcNotation, AbcHeader } from '@/lib/abcParser';
+import dynamic from 'next/dynamic';
+
+// Dynamically import the renderer component, disabling SSR
+const AbcNotationRenderer = dynamic(() => import('@/components/AbcNotationRenderer'), {
+  ssr: false,
+  loading: () => <p>Loading renderer...</p> // Optional loading indicator
+});
+
+const NewPhrasePage: React.FC = () => {
+  const initialAbc = `
+X:1
+T: New Phrase Title
+M: 4/4
+L: 1/8
+K: C
+C D E F | G A B c |
+c B A G | F E D C |`;
+
+  const [abcInput, setAbcInput] = useState<string>(initialAbc);
+  const [parsedHeader, setParsedHeader] = useState<AbcHeader | null>(null);
+  const [parseError, setParseError] = useState<string>('');
+  const [renderError, setRenderError] = useState<Error | null>(null); // State for rendering error
+  const [comment, setComment] = useState<string>(''); // State for comment
+  const [tagsInput, setTagsInput] = useState<string>(''); // State for tags input string
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false); // State for submission status
+  const [submitError, setSubmitError] = useState<string>(''); // State for submission error
+
+  // Parses header, does not validate syntax deeply
+  const handleValidation = useCallback(() => {
+    setParseError(''); // Reset parse error initially
+    setParsedHeader(null);
+    setRenderError(null); // Also reset render error, it will be set by the renderer
+
+    if (!abcInput.trim()) {
+        // If input is empty or only whitespace, clear header and return
+        setParsedHeader(null);
+        return;
+    }
+
+    try {
+      const result = parseAbcNotation(abcInput);
+      if (result) {
+        setParsedHeader(result.header);
+      } else {
+        // This case might be less likely now, but keep for unexpected issues
+        setParseError('Failed to process ABC notation.');
+      }
+    } catch (error) {
+      // Catch internal errors during basic parsing
+      console.error('Internal parsing error:', error);
+      setParseError(`An internal error occurred during parsing: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }, [abcInput]);
+
+  useEffect(() => {
+    handleValidation();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [handleValidation]);
+
+  // Memoize handleRenderError to prevent infinite loops
+  const handleRenderError = useCallback((error: Error | null) => {
+    // Optimize state updates: only update if the value actually changes
+    setRenderError(currentError => {
+      // Basic comparison for Error objects (might need refinement if error identity changes)
+      if (currentError?.message === error?.message) return currentError;
+      return error;
+    });
+    if (error) {
+      setParseError(''); // Clear internal parse error if render error occurs
+    }
+  }, []);
+
+  // Validity now primarily depends on the renderError and submission status
+  const isValidForSubmission = !renderError && !isSubmitting;
+
+  const handleRegister = async () => {
+    // Use the new validity check for submission
+    if (!isValidForSubmission) {
+      console.error("Rendering error or already submitting. Cannot register.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setSubmitError('');
+
+    // Simple tag parsing (split by comma, trim whitespace)
+    const tags = tagsInput.split(',').map(tag => tag.trim()).filter(tag => tag !== '');
+
+    try {
+      const response = await fetch('/api/phrases', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ abcNotation: abcInput, comment, tags }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || `HTTP error! status: ${response.status}`);
+      }
+
+      const savedPhrase = await response.json();
+      console.log('Phrase registered successfully:', savedPhrase);
+      alert(`フレーズが登録されました！\nID: ${savedPhrase.id}`);
+      // TODO: Redirect to the phrase list page or the new phrase page
+      // router.push('/phrases');
+      // Reset form ?
+      // setAbcInput('');
+      // setComment('');
+      // setTagsInput('');
+    } catch (error) {
+      console.error('Error registering phrase:', error);
+      setSubmitError(`登録中にエラーが発生しました: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">フレーズの新規登録</h1>
+
+      <form onSubmit={(e) => { e.preventDefault(); handleRegister(); }}> {/* Add form tag */}
+        <div className="mb-6">
+          <label htmlFor="abcInput" className="block text-xl font-semibold mb-2">ABC Notation:</label>
+          <textarea
+            id="abcInput"
+            className="w-full h-60 p-2 border rounded font-mono text-sm"
+            value={abcInput}
+            onChange={(e) => setAbcInput(e.target.value)}
+            placeholder="X:1\nT:Title\nM:4/4\nL:1/8\nK:C\nCDEF|GABc|"
+            required // Add basic required validation
+          />
+        </div>
+
+        <div className="mb-6">
+          <label htmlFor="comment" className="block text-xl font-semibold mb-2">コメント:</label>
+          <textarea
+            id="comment"
+            className="w-full h-20 p-2 border rounded text-sm"
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+            placeholder="フレーズの説明や使い方のメモなど"
+          />
+        </div>
+
+        <div className="mb-6">
+          <label htmlFor="tagsInput" className="block text-xl font-semibold mb-2">タグ (カンマ区切り):</label>
+          <input
+            type="text"
+            id="tagsInput"
+            className="w-full p-2 border rounded text-sm"
+            value={tagsInput}
+            onChange={(e) => setTagsInput(e.target.value)}
+            placeholder="例: Major 2-5-1, Bebop Scale, Lick"
+          />
+        </div>
+
+        {(parseError || renderError || submitError) && (
+          <div className="mb-4 p-3 bg-red-100 text-red-700 border border-red-400 rounded">
+            {/* Display internal parse error only if no render error exists */}
+            {parseError && !renderError && <p><strong>内部パースエラー:</strong> {parseError}</p>}
+            {renderError && <p><strong>楽譜レンダリングエラー:</strong> {renderError.message}</p>}
+            {submitError && <p><strong>登録エラー:</strong> {submitError}</p>}
+          </div>
+        )}
+
+        {/* Display parsed header only if no render error and header exists */}
+        {!renderError && parsedHeader && (
+          <div className="mb-6 p-4 border rounded bg-gray-50">
+            <h2 className="text-xl font-semibold mb-2">Parsed Header Information:</h2>
+            <pre className="text-sm">{JSON.stringify(parsedHeader, null, 2)}</pre>
+          </div>
+        )}
+
+        <div>
+          <h2 className="text-xl font-semibold mb-2">Preview:</h2>
+          <div className="p-4 border rounded min-h-[100px]">
+            {/* Pass the handleRenderError callback */}
+            <AbcNotationRenderer abcNotation={abcInput} onError={handleRenderError} />
+          </div>
+        </div>
+
+        <div className="mt-6">
+          <button
+            type="submit"
+            className={`px-4 py-2 rounded ${isValidForSubmission ? 'bg-blue-500 text-white hover:bg-blue-600' : 'bg-gray-300 text-gray-500 cursor-not-allowed'}`}
+            disabled={!isValidForSubmission} // Use the new validity check
+          >
+            {isSubmitting ? '登録中...' : '登録'}
+          </button>
+        </div>
+      </form> {/* Close form tag */}
+
+    </div>
+  );
+};
+
+export default NewPhrasePage;
+
+

--- a/src/components/AbcNotationRenderer.tsx
+++ b/src/components/AbcNotationRenderer.tsx
@@ -14,6 +14,7 @@ interface AbcNotationRendererProps {
   engraverParams?: object; // Use generic object type for engraverParams
   // renderParams?: RenderParams;     // Use imported type - Changed to object
   renderParams?: object; // Use generic object type for renderParams
+  onError?: (error: Error | null) => void; // Add onError callback prop
 }
 
 const AbcNotationRenderer: React.FC<AbcNotationRendererProps> = ({
@@ -21,6 +22,7 @@ const AbcNotationRenderer: React.FC<AbcNotationRendererProps> = ({
   parserParams = {},
   engraverParams = {},
   renderParams = {},
+  onError, // Destructure onError prop
 }) => {
   const notationRef = useRef<HTMLDivElement>(null);
   const [isScriptLoaded, setIsScriptLoaded] = React.useState(false);
@@ -33,6 +35,7 @@ const AbcNotationRenderer: React.FC<AbcNotationRendererProps> = ({
       if (notationRef.current && abcNotation) {
         // Clear previous notation
         notationRef.current.innerHTML = '';
+        console.log('[AbcRenderer] Attempting to render ABC:', abcNotation.substring(0, 100) + '...'); // DEBUG LOG
 
         try {
           // Combine params into a single options object
@@ -43,21 +46,48 @@ const AbcNotationRenderer: React.FC<AbcNotationRendererProps> = ({
           };
 
           // Use the global ABCJS object
-          ABCJS.renderAbc(
+          const visualObj = ABCJS.renderAbc( // Assign result to check for warnings/errors
             notationRef.current,
             abcNotation,
             options
           );
+
+          // Check for warnings in the returned object (abcjs might put errors here)
+          if (visualObj && visualObj.length > 0 && visualObj[0].warnings) {
+              console.warn('[AbcRenderer] ABCJS warnings:', visualObj[0].warnings); // DEBUG LOG
+              // Treat warnings as errors for validation purposes
+              const error = new Error(`ABC Notation Warning/Error: ${visualObj[0].warnings.join(', ')}`);
+              if (onError) {
+                  onError(error);
+              }
+              // Optional: Display warning in the UI as well
+              // notationRef.current.innerHTML = `<p class=\"text-orange-500\">楽譜のレンダリング中に警告が発生しました: ${visualObj[0].warnings.join(\', \')}</p>`;
+          } else {
+              console.log('[AbcRenderer] ABC rendering successful (no warnings).'); // DEBUG LOG
+              // If rendering is successful, notify with null error
+              if (onError) {
+                  onError(null);
+              }
+          }
         } catch (error) {
-          console.error('Error rendering ABC notation:', error);
+          console.error('[AbcRenderer] ABC rendering failed! Error caught:', error); // DEBUG LOG
           notationRef.current.innerHTML = '<p class="text-red-500">楽譜のレンダリング中にエラーが発生しました。</p>';
+          // If rendering fails, notify with the error object
+          if (onError) {
+            onError(error instanceof Error ? error : new Error(String(error)));
+          }
         }
       } else if (notationRef.current) {
         notationRef.current.innerHTML = '';
+        console.log('[AbcRenderer] Clearing notation (no abcInput).'); // DEBUG LOG
+        // Also notify that there's no error when input is cleared
+        if (onError) {
+            onError(null);
+        }
       }
     }
-  // Depend on isScriptLoaded and other relevant props
-  }, [isScriptLoaded, abcNotation, parserParams, engraverParams, renderParams]);
+  // Depend on isScriptLoaded and other relevant props, including onError
+  }, [isScriptLoaded, abcNotation, parserParams, engraverParams, renderParams, onError]); // Add onError to dependency array
 
   return (
     <>


### PR DESCRIPTION
Issue #5 に対応し、ユーザーがフレーズを管理するための基本的な CRUD (作成・読み取り・更新・削除) 機能を実装しました。

**主な変更点:**

1.  **フレーズ登録機能 (`/phrases/new`, `POST /api/phrases`)**
    *   ABC Notation、コメント、タグ（カンマ区切り）を入力して新しいフレーズを作成する画面と API を実装しました。
    *   ABC Notation のリアルタイムプレビューと構文・レンダリングバリデーションを実装しました。エラーがある場合は登録ボタンが無効になります。
    *   タグはデータベース内で検索または新規作成 (`user_defined` タイプ) され、フレーズに関連付けられます。
    *   API は認証が必須です。

2.  **フレーズ編集機能 (`/phrases/[id]/edit`, `GET /api/phrases/[id]`, `PUT /api/phrases/[id]`)**
    *   既存フレーズの情報を読み込んで編集する画面と API を実装しました。
    *   登録時と同様のリアルタイムプレビューとバリデーションが適用されます。
    *   タグの更新にも対応しています（既存の関連を解除し、新しいリストで接続・作成）。
    *   API は認証が必須であり、フレーズの所有者（作成者）のみが編集可能です。

3.  **フレーズ削除機能 (`DELETE /api/phrases/[id]`)**
    *   指定された ID のフレーズを削除する API を実装しました。
    *   API は認証が必須であり、フレーズの所有者のみが削除可能です。

4.  **バックエンド改善・修正**
    *   認証方法を Auth.js (next-auth v5) の推奨方式 (`auth()` 関数) に更新しました。
    *   API ルートで `params` を安全に使用するための修正を行いました。
    *   Prisma スキーマを利用し、データベースとの連携を実装しました。

5.  **フロントエンド改善・修正**
    *   `useCallback` を使用して不要な再レンダリングループを解消し、`Maximum update depth exceeded` エラーを修正しました。
    *   編集画面にデータ読み込み中のローディング表示とエラー表示を追加しました。
    *   編集画面に「キャンセル」ボタンを追加しました。

6.  **開発環境・ドキュメント**
    *   `docker-compose.yml` に Prisma Studio 用のポートフォワーディング設定を追加しました。
    *   `README.md` に開発環境のセットアップ手順（`.env` ファイルの準備、Docker 起動）、Prisma Studio の使い方、およびフレーズ登録機能の概要を追記・更新しました。

**備考:**

*   API テストは今回スキップしました。
*   フレーズ一覧画面および詳細画面は未実装です。編集画面へは直接 URL (`/phrases/[id]/edit`) でアクセスする必要があります。
*   削除機能は現在 API のみで、UI 上のボタンはありません。